### PR TITLE
Extended open_mailbox to support folders

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -302,9 +302,11 @@ class ImapLibrary(object):
         - ``text``: Email body text. (Default None)
         - ``timeout``: The maximum value in seconds to wait for email message to arrived.
                        (Default 60)
+        - ``folder``: The email folder to check for emails. (Default INBOX)
 
         Examples:
         | Wait For Email | sender=noreply@domain.com |
+        | Wait For Email | sender=noreply@domain.com | folder=OUTBOX
         """
         poll_frequency = float(kwargs.pop('poll_frequency', 10))
         timeout = int(kwargs.pop('timeout', 60))
@@ -349,9 +351,10 @@ class ImapLibrary(object):
 
     def _check_emails(self, **kwargs):
         """Returns filtered email."""
+        folder = '"%s"' % str(kwargs.pop('folder', self.FOLDER))
         criteria = self._criteria(**kwargs)
         # Calling select before each search is necessary with gmail
-        status, data = self._imap.select()
+        status, data = self._imap.select(folder)
         if status != 'OK':
             raise Exception("imap.select error: %s, %s" % (status, data))
         typ, msgnums = self._imap.search(None, *criteria)

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -68,6 +68,7 @@ class ImapLibrary(object):
 
     PORT = 143
     PORT_SECURE = 993
+    FOLDER = 'INBOX'
     ROBOT_LIBRARY_SCOPE = 'GLOBAL'
     ROBOT_LIBRARY_VERSION = __version__
 
@@ -268,18 +269,21 @@ class ImapLibrary(object):
         - ``password``: The plaintext password to be use to authenticate mailbox on given ``host``.
         - ``port``: The IMAP port number. (Default None)
         - ``user``: The username to be use to authenticate mailbox on given ``host``.
+        - ``folder``: The email folder to read from. (Default INBOX)
 
         Examples:
         | Open Mailbox | host=HOST | user=USER | password=SECRET |
         | Open Mailbox | host=HOST | user=USER | password=SECRET | is_secure=False |
         | Open Mailbox | host=HOST | user=USER | password=SECRET | port=8000 |
+        | Open Mailbox | host=HOST | user=USER | password=SECRET | folder=Drafts
         """
         host = kwargs.pop('host', kwargs.pop('server', None))
         is_secure = kwargs.pop('is_secure', 'True') == 'True'
         port = int(kwargs.pop('port', self.PORT_SECURE if is_secure else self.PORT))
+        folder = '"%s"' % str(kwargs.pop('folder', self.FOLDER))
         self._imap = IMAP4_SSL(host, port) if is_secure else IMAP4(host, port)
         self._imap.login(kwargs.pop('user', None), kwargs.pop('password', None))
-        self._imap.select()
+        self._imap.select(folder)
         self._init_multipart_walk()
 
     def wait_for_email(self, **kwargs):

--- a/test/utest/test_imaplibrary.py
+++ b/test/utest/test_imaplibrary.py
@@ -42,6 +42,8 @@ class ImapLibraryTests(unittest.TestCase):
         self.subject = 'subject'
         self.text = 'text'
         self.username = 'username'
+        self.folder = 'INBOX'
+        self.folder_check = '"INBOX"'
 
     def test_should_have_default_values(self):
         """Imap library instance should have default values set."""
@@ -54,6 +56,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.assertIsNone(self.library._part)
         self.assertEqual(self.library.PORT, self.port)
         self.assertEqual(self.library.PORT_SECURE, self.port_secure)
+        self.assertEqual(self.library.FOLDER, self.folder)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_open_secure_mailbox(self, mock_imap):
@@ -64,7 +67,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password)
         mock_imap.assert_called_with(self.server, self.port_secure)
         self.library._imap.login.assert_called_with(self.username, self.password)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_open_secure_mailbox_with_custom_port(self, mock_imap):
@@ -75,7 +78,18 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password, port=8000)
         mock_imap.assert_called_with(self.server, 8000)
         self.library._imap.login.assert_called_with(self.username, self.password)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
+
+    @mock.patch('ImapLibrary.IMAP4_SSL')
+    def test_should_open_secure_mailbox_with_custom_folder(self, mock_imap):
+        """Open mailbox should open secure connection to IMAP server with
+        requested credentials to a custom folder
+        """
+        self.library.open_mailbox(host=self.server, user=self.username,
+                                  password=self.password, folder='Outbox')
+        mock_imap.assert_called_with(self.server, self.port_secure)
+        self.library._imap.login.assert_called_with(self.username, self.password)
+        self.library._imap.select.assert_called_with('"Outbox"')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_open_secure_mailbox_with_server_key(self, mock_imap):
@@ -86,7 +100,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password)
         mock_imap.assert_called_with(self.server, self.port_secure)
         self.library._imap.login.assert_called_with(self.username, self.password)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
 
     @mock.patch('ImapLibrary.IMAP4')
     def test_should_open_non_secure_mailbox(self, mock_imap):
@@ -97,7 +111,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password, is_secure=False)
         mock_imap.assert_called_with(self.server, self.port)
         self.library._imap.login.assert_called_with(self.username, self.password)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_return_email_index(self, mock_imap):
@@ -254,7 +268,7 @@ class ImapLibraryTests(unittest.TestCase):
             self.library.wait_for_email(sender=self.sender, poll_frequency=0.2,
                                         timeout=0.3)
             self.assertTrue("No email received within 0s" in context.exception)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_raise_exception_on_select_error(self, mock_imap):

--- a/test/utest/test_imaplibrary.py
+++ b/test/utest/test_imaplibrary.py
@@ -44,6 +44,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.username = 'username'
         self.folder = 'INBOX'
         self.folder_check = '"INBOX"'
+        self.folder_filter = '"OUTBOX"'
 
     def test_should_have_default_values(self):
         """Imap library instance should have default values set."""
@@ -121,7 +122,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(sender=self.sender)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
@@ -136,17 +137,17 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(sender=self.sender)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(from_email=self.sender)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(fromEmail=self.sender)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
@@ -161,20 +162,20 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(recipient=self.recipient)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
                                                      self.recipient)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(to_email=self.recipient)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
                                                      self.recipient)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(toEmail=self.recipient)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
                                                      self.recipient)
-        self.assertEqual(index, '0')
+        self.assertEqual(index, '0')      
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_return_email_index_with_subject_filter(self, mock_imap):
@@ -186,7 +187,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(subject=self.subject)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'SUBJECT', '"%s"' %
                                                      self.subject)
         self.assertEqual(index, '0')
@@ -199,7 +200,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(text=self.text)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'TEXT', '"%s"' %
                                                      self.text)
         self.assertEqual(index, '0')
@@ -212,8 +213,23 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(status=self.status)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, self.status)
+        self.assertEqual(index, '0')
+
+    @mock.patch('ImapLibrary.IMAP4_SSL')
+    def test_should_return_email_index_with_folder_filter(self, mock_imap):
+        """Returns email index from connected IMAP session with
+        folder filter.
+        """
+        self.library.open_mailbox(host=self.server, user=self.username,
+                                  password=self.password)
+        self.library._imap.select.return_value = ['OK', ['1']]
+        self.library._imap.search.return_value = ['OK', ['0']]
+        index = self.library.wait_for_email(folder='OUTBOX')
+        self.library._imap.select.return_value = ['OK', ['1']]
+        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.select.assert_called_with(self.folder_filter)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -224,7 +240,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_email()
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, self.status)
         self.assertEqual(index, '0')
 
@@ -239,7 +255,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.return_value = ['OK', ['0']]
         index = self.library.wait_for_mail(sender=self.sender)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
@@ -252,7 +268,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library._imap.select.return_value = ['OK', ['1']]
         self.library._imap.search.side_effect = [['OK', ['']], ['OK', ['0']]]
         index = self.library.wait_for_email(sender=self.sender, poll_frequency=0.2)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
         self.assertEqual(index, '0')
@@ -279,7 +295,7 @@ class ImapLibraryTests(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             self.library.wait_for_email(sender=self.sender)
             self.assertTrue("imap.select error: NOK, ['1']" in context.exception)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_raise_exception_on_search_error(self, mock_imap):
@@ -292,7 +308,7 @@ class ImapLibraryTests(unittest.TestCase):
             self.library.wait_for_email(sender=self.sender)
             self.assertTrue("imap.search error: NOK, [''], criteria=['FROM', '%s']" %
                             self.sender in context.exception)
-        self.library._imap.select.assert_called_with()
+        self.library._imap.select.assert_called_with(self.folder_check)
         self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
                                                      self.sender)
 


### PR DESCRIPTION
I needed functionality to open a mailbox to a certain folder so I extended your functionality. Also included unit tests. There was one weird bug with the .select call where I had to do some trickery with quotes to get it to work. I believe its a bug in the imaplib library. The functionality without specifying folder is maintained since .select() defaults to 'INBOX' in imaplib to begin with.