### PR TITLE
Use imaplib `uid` function to avoid races with concurrent IMAP clients

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -101,7 +101,7 @@ class ImapLibrary(object):
         | Delete All Emails |
         """
         for mail in self._mails:
-            self._imap.store(mail, '+FLAGS', r'\DELETED')
+            self.delete_email(mail)
         self._imap.expunge()
 
     def delete_email(self, email_index):
@@ -113,7 +113,7 @@ class ImapLibrary(object):
         Examples:
         | Delete Email | INDEX |
         """
-        self._imap.store(email_index, '+FLAGS', r'\DELETED')
+        self._imap.uid('store', email_index, '+FLAGS', r'(\DELETED)')
         self._imap.expunge()
 
     def get_email_body(self, email_index):
@@ -129,7 +129,7 @@ class ImapLibrary(object):
         if self._is_walking_multipart(email_index):
             body = self.get_multipart_payload(decode=True)
         else:
-            body = self._imap.fetch(email_index, '(BODY[TEXT])')[1][0][1].decode('quoted-printable')
+            body = self._imap.uid('fetch', email_index, '(BODY[TEXT])')[1][0][1].decode('quoted-printable')
         return body
 
     def get_links_from_email(self, email_index):
@@ -210,7 +210,7 @@ class ImapLibrary(object):
         | Mark All Emails As Read |
         """
         for mail in self._mails:
-            self._imap.store(mail, '+FLAGS', r'\SEEN')
+            self._imap.uid('store', mail, '+FLAGS', r'\SEEN')
 
     def mark_as_read(self):
         """****DEPRECATED****
@@ -227,7 +227,7 @@ class ImapLibrary(object):
         Examples:
         | Mark Email As Read | INDEX |
         """
-        self._imap.store(email_index, '+FLAGS', r'\SEEN')
+        self._imap.uid('store', email_index, '+FLAGS', r'\SEEN')
 
     def open_link_from_email(self, email_index, link_index=0):
         """Open link URL from given ``link_index`` in email message body of given ``email_index``.
@@ -338,7 +338,7 @@ class ImapLibrary(object):
         | Walk Multipart Email | INDEX |
         """
         if not self._is_walking_multipart(email_index):
-            data = self._imap.fetch(email_index, '(RFC822)')[1][0][1]
+            data = self._imap.uid('fetch', email_index, '(RFC822)')[1][0][1]
             msg = message_from_string(data)
             self._start_multipart_walk(email_index, msg)
         try:
@@ -357,7 +357,7 @@ class ImapLibrary(object):
         status, data = self._imap.select(folder)
         if status != 'OK':
             raise Exception("imap.select error: %s, %s" % (status, data))
-        typ, msgnums = self._imap.search(None, *criteria)
+        typ, msgnums = self._imap.uid('search', None, *criteria)
         if typ != 'OK':
             raise Exception('imap.search error: %s, %s, criteria=%s' % (typ, msgnums, criteria))
         return msgnums[0].split()

--- a/test/utest/test_imaplibrary.py
+++ b/test/utest/test_imaplibrary.py
@@ -120,11 +120,11 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(sender=self.sender)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                    '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -135,21 +135,21 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(sender=self.sender)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                    '"%s"' % self.sender)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(from_email=self.sender)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                    '"%s"' % self.sender)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(fromEmail=self.sender)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                    '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -160,21 +160,21 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(recipient=self.recipient)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
-                                                     self.recipient)
+        self.library._imap.uid.assert_called_with('search', None, 'TO',
+                                                     '"%s"' % self.recipient)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(to_email=self.recipient)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
-                                                     self.recipient)
+        self.library._imap.uid.assert_called_with('search', None, 'TO',
+                                                     '"%s"' % self.recipient)
         self.assertEqual(index, '0')
         index = self.library.wait_for_email(toEmail=self.recipient)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'TO', '"%s"' %
-                                                     self.recipient)
+        self.library._imap.uid.assert_called_with('search', None, 'TO',
+                                                     '"%s"' % self.recipient)
         self.assertEqual(index, '0')      
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -185,11 +185,11 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(subject=self.subject)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'SUBJECT', '"%s"' %
-                                                     self.subject)
+        self.library._imap.uid.assert_called_with('search', None, 'SUBJECT',
+                                                     '"%s"' % self.subject)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -198,11 +198,11 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(text=self.text)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'TEXT', '"%s"' %
-                                                     self.text)
+        self.library._imap.uid.assert_called_with('search', None, 'TEXT',
+                                                     '"%s"' % self.text)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -211,10 +211,10 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(status=self.status)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, self.status)
+        self.library._imap.uid.assert_called_with('search', None, self.status)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -225,10 +225,10 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email(folder='OUTBOX')
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         self.library._imap.select.assert_called_with(self.folder_filter)
         self.assertEqual(index, '0')
 
@@ -238,10 +238,10 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_email()
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, self.status)
+        self.library._imap.uid.assert_called_with('search', None, self.status)
         self.assertEqual(index, '0')
 
     # DEPRECATED
@@ -253,11 +253,11 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['0']]
+        self.library._imap.uid.return_value = ['OK', ['0']]
         index = self.library.wait_for_mail(sender=self.sender)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                     '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -266,11 +266,11 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.side_effect = [['OK', ['']], ['OK', ['0']]]
+        self.library._imap.uid.side_effect = [['OK', ['']], ['OK', ['0']]]
         index = self.library.wait_for_email(sender=self.sender, poll_frequency=0.2)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
-                                                     self.sender)
+        self.library._imap.uid.assert_called_with('search', None, 'FROM',
+                                                     '"%s"' % self.sender)
         self.assertEqual(index, '0')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -279,7 +279,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['OK', ['']]
+        self.library._imap.uid.return_value = ['OK', ['']]
         with self.assertRaises(AssertionError) as context:
             self.library.wait_for_email(sender=self.sender, poll_frequency=0.2,
                                         timeout=0.3)
@@ -303,13 +303,13 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library._imap.select.return_value = ['OK', ['1']]
-        self.library._imap.search.return_value = ['NOK', ['']]
+        self.library._imap.uid.return_value = ['NOK', ['']]
         with self.assertRaises(Exception) as context:
             self.library.wait_for_email(sender=self.sender)
             self.assertTrue("imap.search error: NOK, [''], criteria=['FROM', '%s']" %
                             self.sender in context.exception)
         self.library._imap.select.assert_called_with(self.folder_check)
-        self.library._imap.search.assert_called_with(None, 'FROM', '"%s"' %
+        self.library._imap.uid.assert_called_with('search', None, 'FROM', '"%s"' %
                                                      self.sender)
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -319,7 +319,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password)
         self.library._mails = ['0']
         self.library.delete_all_emails()
-        self.library._imap.store.assert_called_with('0', '+FLAGS', r'\DELETED')
+        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'(\DELETED)')
         self.library._imap.expunge.assert_called_with()
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -328,7 +328,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library.delete_email('0')
-        self.library._imap.store.assert_called_with('0', '+FLAGS', r'\DELETED')
+        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'(\DELETED)')
         self.library._imap.expunge.assert_called_with()
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -338,7 +338,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password)
         self.library._mails = ['0']
         self.library.mark_all_emails_as_read()
-        self.library._imap.store.assert_called_with('0', '+FLAGS', r'\SEEN')
+        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
 
     # DEPRECATED
     @mock.patch('ImapLibrary.IMAP4_SSL')
@@ -348,7 +348,7 @@ class ImapLibraryTests(unittest.TestCase):
                                   password=self.password)
         self.library._mails = ['0']
         self.library.mark_as_read()
-        self.library._imap.store.assert_called_with('0', '+FLAGS', r'\SEEN')
+        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_mark_email_as_read(self, mock_imap):
@@ -356,7 +356,7 @@ class ImapLibraryTests(unittest.TestCase):
         self.library.open_mailbox(host=self.server, user=self.username,
                                   password=self.password)
         self.library.mark_email_as_read('0')
-        self.library._imap.store.assert_called_with('0', '+FLAGS', r'\SEEN')
+        self.library._imap.uid.assert_called_with('store', '0', '+FLAGS', r'\SEEN')
 
     @mock.patch('ImapLibrary.IMAP4_SSL')
     def test_should_close_mailbox(self, mock_imap):


### PR DESCRIPTION
This commit fixes issue with concurrent access to the same server by multiple IMAP clients. Instead of using IMAP message number, which is volatile, it refers to all emails with uid, which is guaranteed to be unique per IMAP session (https://tools.ietf.org/html/rfc3501#section-2.3.1.1). This protects against changes in the mailbox done by other clients accessing the same server concurrently, as well as changes made by the client itself causing renumeration of previous messages.