### PR TITLE
use codecs module to decode quoted printable email bodys

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -22,6 +22,7 @@ IMAP Library - a IMAP email testing library.
 from email import message_from_string
 from imaplib import IMAP4, IMAP4_SSL
 from re import findall
+from codecs import decode
 from time import sleep, time
 try:
     from urllib.request import urlopen
@@ -129,10 +130,8 @@ class ImapLibrary(object):
         if self._is_walking_multipart(email_index):
             body = self.get_multipart_payload(decode=True)
         else:
-            body = self._imap.uid('fetch',
-                                  email_index,
-                                  '(BODY[TEXT])')[1][0][1].\
-                decode('quoted-printable')
+            encoded_body = self._imap.uid('fetch', email_index, '(BODY[TEXT])')[1][0][1]
+            body = decode(encoded_body, 'quopri_codec').decode('utf-8')
         return body
 
     def get_links_from_email(self, email_index):


### PR DESCRIPTION
We're using Python 3.5 and we kept getting this error when parsing emails:

```
Documentation:	
Returns all links found in the email body from given email_index.
Start / End / Elapsed:	20170609 14:05:28.333 / 20170609 14:05:28.500 / 00:00:00.167
14:05:28.334	TRACE	Arguments: [ b'21' ]	
14:05:28.499	FAIL	LookupError: 'quoted-printable' is not a text encoding; use codecs.decode() to handle arbitrary codecs	
14:05:28.499	DEBUG	Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/ImapLibrary/__init__.py", line 147, in get_links_from_email
    body = self.get_email_body(email_index)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/ImapLibrary/__init__.py", line 135, in get_email_body
    decode('quoted-printable')
```

The attached code fixes that by using the `codecs` module [https://docs.python.org/3.6/library/codecs.html] to parse the quoted printable email bodies