### PR TITLE
Making Imaplibrary compatible with Python 3

### DIFF
--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -19,7 +19,7 @@
 IMAP Library - a IMAP email testing library.
 """
 
-from email import message_from_string
+from email import message_from_bytes
 from imaplib import IMAP4, IMAP4_SSL
 from re import findall
 from time import sleep, time
@@ -342,7 +342,7 @@ class ImapLibrary(object):
         """
         if not self._is_walking_multipart(email_index):
             data = self._imap.uid('fetch', email_index, '(RFC822)')[1][0][1]
-            msg = message_from_string(data)
+            msg = message_from_bytes(data)
             self._start_multipart_walk(email_index, msg)
         try:
             self._part = next(self._mp_iter)

--- a/src/ImapLibrary/__init__.py
+++ b/src/ImapLibrary/__init__.py
@@ -248,7 +248,7 @@ class ImapLibrary(object):
 
         if len(urls) > link_index:
             resp = urlopen(urls[link_index])
-            content_type = resp.headers.getheader('content-type')
+            content_type = resp.headers.get('content-type')
             if content_type:
                 enc = content_type.split('charset=')[-1]
                 return ustr(resp.read(), enc)


### PR DESCRIPTION
replaces `message_from_string` with `message_from_bytes` in init.py